### PR TITLE
Improve handling of IDX_LOW and IDX_HIGH in pulsed measurements

### DIFF
--- a/ac_stark_shift.py
+++ b/ac_stark_shift.py
@@ -14,13 +14,10 @@ import numpy.typing as npt
 from presto import pulsed
 from presto.utils import rotate_opt, sin2
 
-from _base import Base
-
-IDX_LOW = 0
-IDX_HIGH = -1
+from _base import PlsBase
 
 
-class AcStarkShift(Base):
+class AcStarkShift(PlsBase):
     def __init__(
         self,
         readout_freq: float,
@@ -299,13 +296,9 @@ class AcStarkShift(Base):
         import matplotlib.pyplot as plt
 
         ret_fig = []
-
-        idx = np.arange(IDX_LOW, IDX_HIGH)
-        t_low = self.t_arr[IDX_LOW]
-        t_high = self.t_arr[IDX_HIGH]
-
         if all_plots:
             # Plot raw store data for first iteration as a check
+            t_low, t_high = self._store_t_analysis()
             fig1, ax1 = plt.subplots(2, 1, sharex=True, tight_layout=True)
             ax11, ax12 = ax1
             ax11.axvspan(1e9 * t_low, 1e9 * t_high, facecolor="#dfdfdf")
@@ -317,7 +310,8 @@ class AcStarkShift(Base):
             ret_fig.append(fig1)
 
         # analyze and reshape data
-        resp_arr = np.mean(self.store_arr[:, 0, idx], axis=-1)
+        idx_low, idx_high = self._store_idx_analysis()
+        resp_arr = np.mean(self.store_arr[:, 0, idx_low:idx_high], axis=-1)
         data = rotate_opt(resp_arr).real
         nr_amps = len(self.ringup_amp_arr)
         nr_delays = len(self.delay_arr)

--- a/cycle_Ts.py
+++ b/cycle_Ts.py
@@ -293,7 +293,7 @@ class CycleTs(Base):
 
         time1_arr = self._time1_arr - self.time_start
         time2_arr = self._time2_arr - self.time_start
-        max_time = max(np.max(time1_arr), np.max(time2_arr))
+        max_time = max(max(time1_arr), max(time2_arr))
         if max_time > 86_400:
             time1_arr /= 86_400
             time2_arr /= 86_400

--- a/displacement_calibration.py
+++ b/displacement_calibration.py
@@ -11,13 +11,10 @@ import numpy.typing as npt
 from presto import pulsed
 from presto.utils import rotate_opt, sin2
 
-from _base import Base
-
-IDX_LOW = 0
-IDX_HIGH = -1
+from _base import PlsBase
 
 
-class DisplacementCalibration(Base):
+class DisplacementCalibration(PlsBase):
     def __init__(
         self,
         readout_freq: float,
@@ -250,14 +247,13 @@ class DisplacementCalibration(Base):
         import matplotlib.pyplot as plt
 
         ret_fig = []
-        t_low = self.t_arr[IDX_LOW]
-        t_high = self.t_arr[IDX_HIGH]
 
         nr_amps = len(self.memory_amp_arr)
         self._AMP_IDX = nr_amps // 2
 
         if all_plots:
             # Plot raw store data for first iteration as a check
+            t_low, t_high = self._store_t_analysis()
             fig0, ax0 = plt.subplots(2, 1, sharex=True, tight_layout=True)
             ax01, ax02 = ax0
             ax01.axvspan(1e9 * t_low, 1e9 * t_high, facecolor="#dfdfdf")
@@ -269,7 +265,8 @@ class DisplacementCalibration(Base):
             ret_fig.append(fig0)
 
         # Analyze
-        resp_arr = np.mean(self.store_arr[:, 0, IDX_LOW:IDX_HIGH], axis=-1)
+        idx_low, idx_high = self._store_idx_analysis()
+        resp_arr = np.mean(self.store_arr[:, 0, idx_low:idx_high], axis=-1)
         resp_arr.shape = (len(self.memory_amp_arr), len(self.control_df_arr))
         resp_arr = rotate_opt(resp_arr)
         resp_arr = resp_arr.real

--- a/excited_sweep.py
+++ b/excited_sweep.py
@@ -10,13 +10,10 @@ import numpy.typing as npt
 from presto import pulsed
 from presto.utils import sin2, untwist_downconversion
 
-from _base import Base
-
-IDX_LOW = 0
-IDX_HIGH = -1
+from _base import PlsBase
 
 
-class ExcitedSweep(Base):
+class ExcitedSweep(PlsBase):
     def __init__(
         self,
         readout_freq_center: float,
@@ -234,16 +231,9 @@ class ExcitedSweep(Base):
             _has_resonator_tools = False
 
         ret_fig = []
-
-        t_low = self.t_arr[IDX_LOW]
-        t_high = self.t_arr[IDX_HIGH]
-        if IDX_HIGH < 0:
-            nr_samples = len(self.t_arr) + IDX_HIGH - IDX_LOW
-        else:
-            nr_samples = IDX_HIGH - IDX_LOW
-
         if all_plots:
             # Plot raw store data for first iteration as a check
+            t_low, t_high = self._store_t_analysis()
             fig1, ax1 = plt.subplots(2, 1, sharex=True, tight_layout=True)
             ax11, ax12 = ax1
             ax11.axvspan(1e9 * t_low, 1e9 * t_high, facecolor="#dfdfdf")
@@ -255,7 +245,9 @@ class ExcitedSweep(Base):
             ret_fig.append(fig1)
 
         # Analyze
-        data = self.store_arr[:, 0, IDX_LOW:IDX_HIGH]
+        idx_low, idx_high = self._store_idx_analysis()
+        nr_samples = len(self.t_arr[idx_low:idx_high])
+        data = self.store_arr[:, 0, idx_low:idx_high]
         data.shape = (self.readout_freq_nr, 2, nr_samples)
         resp_I_arr = np.zeros((2, self.readout_freq_nr), np.complex128)
         resp_Q_arr = np.zeros((2, self.readout_freq_nr), np.complex128)

--- a/jpa_sweep_bias.py
+++ b/jpa_sweep_bias.py
@@ -203,8 +203,8 @@ class JpaSweepBias(Base):
 
         # choose limits for colorbar
         cutoff = 10.0  # %
-        lowlim = np.percentile(data, cutoff)
-        highlim = np.percentile(data, 100.0 - cutoff)
+        lowlim = float(np.percentile(data, cutoff))
+        highlim = float(np.percentile(data, 100.0 - cutoff))
 
         # extent
         x_min = 1e-9 * self.freq_arr[0]

--- a/jpa_sweep_power_bias.py
+++ b/jpa_sweep_power_bias.py
@@ -232,8 +232,8 @@ class JpaSweepPowerBias(Base):
 
         # choose limits for colorbar
         cutoff = 1.0  # %
-        lowlim = np.percentile(gain_db, cutoff)
-        highlim = np.percentile(gain_db, 100.0 - cutoff)
+        lowlim = float(np.percentile(gain_db, cutoff))
+        highlim = float(np.percentile(gain_db, 100.0 - cutoff))
         abslim = max(abs(lowlim), abs(highlim))
 
         # extent

--- a/rabi_amp.py
+++ b/rabi_amp.py
@@ -16,13 +16,10 @@ import numpy.typing as npt
 from presto import pulsed
 from presto.utils import format_precision, rotate_opt, sin2
 
-from _base import Base
-
-IDX_LOW = 0
-IDX_HIGH = -1
+from _base import PlsBase
 
 
-class RabiAmp(Base):
+class RabiAmp(PlsBase):
     def __init__(
         self,
         readout_freq: float,
@@ -218,11 +215,9 @@ class RabiAmp(Base):
         import matplotlib.pyplot as plt
 
         ret_fig = []
-        t_low = self.t_arr[IDX_LOW]
-        t_high = self.t_arr[IDX_HIGH]
-
         if all_plots:
             # Plot raw store data for first iteration as a check
+            t_low, t_high = self._store_t_analysis()
             fig1, ax1 = plt.subplots(2, 1, sharex=True, tight_layout=True)
             ax11, ax12 = ax1
             ax11.axvspan(1e9 * t_low, 1e9 * t_high, facecolor="#dfdfdf")
@@ -234,7 +229,8 @@ class RabiAmp(Base):
             ret_fig.append(fig1)
 
         # Analyze Rabi
-        resp_arr = np.mean(self.store_arr[:, 0, IDX_LOW:IDX_HIGH], axis=-1)
+        idx_low, idx_high = self._store_idx_analysis()
+        resp_arr = np.mean(self.store_arr[:, 0, idx_low:idx_high], axis=-1)
         data = rotate_opt(resp_arr)
 
         # Fit data

--- a/rabi_amp_square.py
+++ b/rabi_amp_square.py
@@ -16,13 +16,10 @@ import numpy.typing as npt
 from presto import pulsed
 from presto.utils import format_precision, rotate_opt
 
-from _base import Base
-
-IDX_LOW = 0
-IDX_HIGH = -1
+from _base import PlsBase
 
 
-class RabiAmp(Base):
+class RabiAmp(PlsBase):
     def __init__(
         self,
         readout_freq: float,
@@ -209,11 +206,9 @@ class RabiAmp(Base):
         import matplotlib.pyplot as plt
 
         ret_fig = []
-        t_low = self.t_arr[IDX_LOW]
-        t_high = self.t_arr[IDX_HIGH]
-
         if all_plots:
             # Plot raw store data for first iteration as a check
+            t_low, t_high = self._store_t_analysis()
             fig1, ax1 = plt.subplots(2, 1, sharex=True, tight_layout=True)
             ax11, ax12 = ax1
             ax11.axvspan(1e9 * t_low, 1e9 * t_high, facecolor="#dfdfdf")
@@ -225,7 +220,8 @@ class RabiAmp(Base):
             ret_fig.append(fig1)
 
         # Analyze Rabi
-        resp_arr = np.mean(self.store_arr[:, 0, IDX_LOW:IDX_HIGH], axis=-1)
+        idx_low, idx_high = self._store_idx_analysis()
+        resp_arr = np.mean(self.store_arr[:, 0, idx_low:idx_high], axis=-1)
         data = rotate_opt(resp_arr)
 
         # Fit data

--- a/rabi_time.py
+++ b/rabi_time.py
@@ -15,13 +15,10 @@ import numpy.typing as npt
 from presto import pulsed
 from presto.utils import rotate_opt
 
-from _base import Base
-
-IDX_LOW = 0
-IDX_HIGH = -1
+from _base import PlsBase
 
 
-class RabiTime(Base):
+class RabiTime(PlsBase):
     def __init__(
         self,
         readout_freq: float,
@@ -203,11 +200,9 @@ class RabiTime(Base):
 
         ret_fig = []
 
-        t_low = self.t_arr[IDX_LOW]
-        t_high = self.t_arr[IDX_HIGH]
-
         if all_plots:
             # Plot raw store data for first iteration as a check
+            t_low, t_high = self._store_t_analysis()
             fig1, ax1 = plt.subplots(2, 1, sharex=True, tight_layout=True)
             ax11, ax12 = ax1
             ax11.axvspan(1e9 * t_low, 1e9 * t_high, facecolor="#dfdfdf")
@@ -219,7 +214,8 @@ class RabiTime(Base):
             ret_fig.append(fig1)
 
         # Analyze Rabi
-        resp_arr = np.mean(self.store_arr[:, 0, IDX_LOW:IDX_HIGH], axis=-1)
+        idx_low, idx_high = self._store_idx_analysis()
+        resp_arr = np.mean(self.store_arr[:, 0, idx_low:idx_high], axis=-1)
         resp_arr.shape = (len(self.control_amp_arr), len(self.control_duration_arr))
         data = rotate_opt(resp_arr)
         plot_data = data.real

--- a/ramsey_echo.py
+++ b/ramsey_echo.py
@@ -11,13 +11,10 @@ import numpy.typing as npt
 from presto import pulsed
 from presto.utils import format_precision, rotate_opt, sin2
 
-from _base import Base, project
-
-IDX_LOW = 0
-IDX_HIGH = -1
+from _base import PlsBase, project
 
 
-class RamseyEcho(Base):
+class RamseyEcho(PlsBase):
     def __init__(
         self,
         readout_freq: float,
@@ -217,8 +214,8 @@ class RamseyEcho(Base):
         assert self.store_arr is not None
 
         if reference_templates is None:
-            idx = np.arange(IDX_LOW, IDX_HIGH)
-            resp_arr = np.mean(self.store_arr[:, 0, idx], axis=-1)
+            idx_low, idx_high = self._store_idx_analysis()
+            resp_arr = np.mean(self.store_arr[:, 0, idx_low:idx_high], axis=-1)
             data = np.real(rotate_opt(resp_arr))
         else:
             resp_arr = self.store_arr[:, 0, :]
@@ -239,12 +236,9 @@ class RamseyEcho(Base):
         import matplotlib.pyplot as plt
 
         ret_fig = []
-
-        t_low = self.t_arr[IDX_LOW]
-        t_high = self.t_arr[IDX_HIGH]
-
         if all_plots:
             # Plot raw store data for first iteration as a check
+            t_low, t_high = self._store_t_analysis()
             fig1, ax1 = plt.subplots(2, 1, sharex=True, tight_layout=True)
             ax11, ax12 = ax1
             ax11.axvspan(1e9 * t_low, 1e9 * t_high, facecolor="#dfdfdf")
@@ -256,7 +250,8 @@ class RamseyEcho(Base):
             ret_fig.append(fig1)
 
         # Analyze T2
-        resp_arr = np.mean(self.store_arr[:, 0, IDX_LOW:IDX_HIGH], axis=-1)
+        idx_low, idx_high = self._store_idx_analysis()
+        resp_arr = np.mean(self.store_arr[:, 0, idx_low:idx_high], axis=-1)
         data = rotate_opt(resp_arr)
 
         # Fit data to I quadrature

--- a/ramsey_fringes.py
+++ b/ramsey_fringes.py
@@ -11,13 +11,10 @@ import numpy.typing as npt
 from presto import pulsed
 from presto.utils import format_precision, rotate_opt, sin2, si_prefix_scale
 
-from _base import Base
-
-IDX_LOW = 0
-IDX_HIGH = -1
+from _base import PlsBase
 
 
-class RamseyFringes(Base):
+class RamseyFringes(PlsBase):
     def __init__(
         self,
         readout_freq: float,
@@ -243,12 +240,9 @@ class RamseyFringes(Base):
         from scipy.optimize import curve_fit
 
         ret_fig = []
-
-        t_low = self.t_arr[IDX_LOW]
-        t_high = self.t_arr[IDX_HIGH]
-
         if all_plots:
             # Plot raw store data for first iteration as a check
+            t_low, t_high = self._store_t_analysis()
             fig1, ax1 = plt.subplots(2, 1, sharex=True, tight_layout=True)
             ax11, ax12 = ax1
             ax11.axvspan(1e9 * t_low, 1e9 * t_high, facecolor="#dfdfdf")
@@ -260,7 +254,8 @@ class RamseyFringes(Base):
             ret_fig.append(fig1)
 
         # Analyze
-        resp_arr = np.mean(self.store_arr[:, 0, IDX_LOW:IDX_HIGH], axis=-1)
+        idx_low, idx_high = self._store_idx_analysis()
+        resp_arr = np.mean(self.store_arr[:, 0, idx_low:idx_high], axis=-1)
         resp_arr.shape = (self.control_freq_nr, len(self.delay_arr))
         data = rotate_opt(resp_arr)
         plot_data = data.real

--- a/ramsey_single.py
+++ b/ramsey_single.py
@@ -15,13 +15,10 @@ import numpy.typing as npt
 from presto import pulsed
 from presto.utils import rotate_opt, sin2
 
-from _base import Base
-
-IDX_LOW = 0
-IDX_HIGH = -1
+from _base import PlsBase
 
 
-class RamseySingle(Base):
+class RamseySingle(PlsBase):
     def __init__(
         self,
         readout_freq: float,
@@ -211,12 +208,9 @@ class RamseySingle(Base):
         import matplotlib.pyplot as plt
 
         ret_fig = []
-
-        t_low = self.t_arr[IDX_LOW]
-        t_high = self.t_arr[IDX_HIGH]
-
         if all_plots:
             # Plot raw store data for first iteration as a check
+            t_low, t_high = self._store_t_analysis()
             fig1, ax1 = plt.subplots(2, 1, sharex=True, tight_layout=True)
             ax11, ax12 = ax1
             ax11.axvspan(1e9 * t_low, 1e9 * t_high, facecolor="#dfdfdf")
@@ -228,7 +222,8 @@ class RamseySingle(Base):
             ret_fig.append(fig1)
 
         # Analyze T2
-        resp_arr = np.mean(self.store_arr[:, 0, IDX_LOW:IDX_HIGH], axis=-1)
+        idx_low, idx_high = self._store_idx_analysis()
+        resp_arr = np.mean(self.store_arr[:, 0, idx_low:idx_high], axis=-1)
         data = rotate_opt(resp_arr)
 
         # Fit data to I quadrature

--- a/rb.py
+++ b/rb.py
@@ -22,16 +22,13 @@ from qiskit_experiments.library import StandardRB
 from presto import pulsed
 from presto.utils import rotate_opt, sin2
 
-from _base import Base
+from _base import PlsBase
 
 Gate: TypeAlias = Tuple[str, int]
 GateSeq: TypeAlias = List[Gate]
 
-IDX_LOW = 0
-IDX_HIGH = -1
 
-
-class Rb(Base):
+class Rb(PlsBase):
     def __init__(
         self,
         readout_freq: float,
@@ -276,7 +273,8 @@ class Rb(Base):
         import matplotlib.pyplot as plt
         from scipy.optimize import curve_fit
 
-        result = _lowpass(self.store_arr[:, :, IDX_LOW:IDX_HIGH])
+        idx_low, idx_high = self._store_idx_analysis()
+        result = _lowpass(self.store_arr[:, :, idx_low:idx_high])
         result_average = np.average(result, axis=-1)
         rotated = np.real(rotate_opt(result_average))
         rotated_avg = np.average(rotated, axis=0)
@@ -325,7 +323,8 @@ class Rb(Base):
         from matplotlib.ticker import ScalarFormatter
         from scipy.optimize import curve_fit
 
-        result = _lowpass(self.store_arr[:, :, IDX_LOW:IDX_HIGH])
+        idx_low, idx_high = self._store_idx_analysis()
+        result = _lowpass(self.store_arr[:, :, idx_low:idx_high])
         result_average = np.average(result, axis=-1)
         rotated = np.real(rotate_opt(result_average))
         rotated_avg = np.average(rotated, axis=0)

--- a/readout_ref.py
+++ b/readout_ref.py
@@ -15,13 +15,10 @@ from presto import pulsed
 from presto.pulsed import MAX_TEMPLATE_LEN
 from presto.utils import sin2, to_pm_pi
 
-from _base import Base
-
-IDX_LOW = 0
-IDX_HIGH = -1
+from _base import PlsBase
 
 
-class ReadoutRef(Base):
+class ReadoutRef(PlsBase):
     def __init__(
         self,
         readout_freq: float,

--- a/readout_ref.py
+++ b/readout_ref.py
@@ -5,7 +5,7 @@ Acquire reference templates for template matching.
 """
 
 import ast
-from typing import Optional
+from typing import Dict, Optional, overload, Literal, Any, Tuple, Union
 
 import h5py
 import numpy as np
@@ -205,7 +205,21 @@ class ReadoutRef(PlsBase):
 
         return self
 
-    def analyze(self, plot: bool = True, rotate: bool = False, match_len: Optional[int] = None):
+    @overload
+    def analyze(
+        self, plot: Literal[True], rotate: bool = False, match_len: Optional[int] = None
+    ) -> Tuple[Dict, Any]: ...
+    @overload
+    def analyze(
+        self, plot: Literal[False], rotate: bool = False, match_len: Optional[int] = None
+    ) -> Dict: ...
+    @overload
+    def analyze(
+        self, plot: bool = True, rotate: bool = False, match_len: Optional[int] = None
+    ) -> Union[Dict, Tuple[Dict, Any]]: ...
+    def analyze(
+        self, plot: bool = True, rotate: bool = False, match_len: Optional[int] = None
+    ) -> Union[Dict, Tuple[Dict, Any]]:
         assert self.t_arr is not None
         assert self.store_arr is not None
 

--- a/readout_reset.py
+++ b/readout_reset.py
@@ -15,13 +15,10 @@ import numpy.typing as npt
 from presto import pulsed
 from presto.utils import sin2
 
-from _base import Base
-
-IDX_LOW = 0
-IDX_HIGH = -1
+from _base import PlsBase
 
 
-class ReadoutReset(Base):
+class ReadoutReset(PlsBase):
     def __init__(
         self,
         readout_freq: float,

--- a/single_shot.py
+++ b/single_shot.py
@@ -15,13 +15,10 @@ import numpy.typing as npt
 from presto import pulsed
 from presto.utils import sin2
 
-from _base import Base
-
-IDX_LOW = 0
-IDX_HIGH = -1
+from _base import PlsBase
 
 
-class SingleShot(Base):
+class SingleShot(PlsBase):
     def __init__(
         self,
         readout_freq: float,

--- a/single_shot_readout.py
+++ b/single_shot_readout.py
@@ -12,10 +12,10 @@ import numpy.typing as npt
 from presto import pulsed
 from presto.utils import rotate_opt, sin2
 
-from _base import Base
+from _base import PlsBase
 
 
-class SingleShotReadout(Base):
+class SingleShotReadout(PlsBase):
     def __init__(
         self,
         readout_freq: float,
@@ -221,10 +221,10 @@ class SingleShotReadout(Base):
         ret_fig = []
 
         fs = 1 / (self.t_arr[1] - self.t_arr[0])
-        IDX_LOW = int(round(self.template_match_start * fs))
-        IDX_HIGH = int(round((self.template_match_start + self.template_match_duration) * fs))
-        t_low = self.t_arr[IDX_LOW]
-        t_high = self.t_arr[IDX_HIGH]
+        idx_low = int(round(self.template_match_start * fs))
+        idx_high = int(round((self.template_match_start + self.template_match_duration) * fs))
+        t_low = self.t_arr[idx_low]
+        t_high = self.t_arr[idx_high]
 
         if all_plots:
             # Plot raw store data for first iteration as a check
@@ -244,8 +244,8 @@ class SingleShotReadout(Base):
         complex_match_data = self.match_arr[0] + 1j * self.match_arr[1]
         avg_data = np.array(
             [
-                np.sum(self.store_arr[0, 0, IDX_LOW:IDX_HIGH]),
-                np.sum(self.store_arr[1, 0, IDX_LOW:IDX_HIGH]),
+                np.sum(self.store_arr[0, 0, idx_low:idx_high]),
+                np.sum(self.store_arr[1, 0, idx_low:idx_high]),
             ]
         )
         if rotate_optimally:

--- a/sweep_freq_and_DC.py
+++ b/sweep_freq_and_DC.py
@@ -233,8 +233,8 @@ class SweepFreqAndDC(Base):
 
         # choose limits for colorbar
         cutoff = 10.0  # %
-        lowlim = np.percentile(data, cutoff)
-        highlim = np.percentile(data, 100.0 - cutoff)
+        lowlim = float(np.percentile(data, cutoff))
+        highlim = float(np.percentile(data, 100.0 - cutoff))
 
         # extent
         x_min = 1e-9 * self.freq_arr[0]

--- a/sweep_freq_and_DC_flux.py
+++ b/sweep_freq_and_DC_flux.py
@@ -203,8 +203,8 @@ class SweepFreqAndDC(Base):
             raise ValueError
 
         cutoff = 5.0  # %
-        lowlim = np.percentile(data, cutoff)
-        highlim = np.percentile(data, 100.0 - cutoff)
+        lowlim = float(np.percentile(data, cutoff))
+        highlim = float(np.percentile(data, 100.0 - cutoff))
         # extent
         x_min = 1e-9 * self.freq_arr[0]
         x_max = 1e-9 * self.freq_arr[-1]

--- a/sweep_memory.py
+++ b/sweep_memory.py
@@ -10,13 +10,10 @@ import numpy.typing as npt
 from presto import pulsed
 from presto.utils import rotate_opt, sin2
 
-from _base import Base
-
-IDX_LOW = 0
-IDX_HIGH = -1
+from _base import PlsBase
 
 
-class Sweep_memory(Base):
+class Sweep_memory(PlsBase):
     def __init__(
         self,
         readout_freq: float,
@@ -236,11 +233,9 @@ class Sweep_memory(Base):
         from scipy.optimize import curve_fit
 
         ret_fig = []
-        t_low = self.t_arr[IDX_LOW]
-        t_high = self.t_arr[IDX_HIGH]
-
         if all_plots:
             # Plot raw store data for first iteration as a check
+            t_low, t_high = self._store_t_analysis()
             fig1, ax1 = plt.subplots(2, 1, sharex=True, tight_layout=True)
             ax11, ax12 = ax1
             ax11.axvspan(1e9 * t_low, 1e9 * t_high, facecolor="#dfdfdf")
@@ -252,7 +247,8 @@ class Sweep_memory(Base):
             ret_fig.append(fig1)
 
         # Analyze
-        resp_arr = np.mean(self.store_arr[:, 0, IDX_LOW:IDX_HIGH], axis=-1)
+        idx_low, idx_high = self._store_idx_analysis()
+        resp_arr = np.mean(self.store_arr[:, 0, idx_low:idx_high], axis=-1)
         data = rotate_opt(resp_arr)
 
         data_max = np.abs(data).max()

--- a/sweep_memory_square_pulses.py
+++ b/sweep_memory_square_pulses.py
@@ -10,13 +10,10 @@ import numpy.typing as npt
 from presto import pulsed
 from presto.utils import rotate_opt
 
-from _base import Base
-
-IDX_LOW = 0
-IDX_HIGH = -1
+from _base import PlsBase
 
 
-class Sweep_memory(Base):
+class Sweep_memory(PlsBase):
     def __init__(
         self,
         readout_freq: float,
@@ -238,11 +235,9 @@ class Sweep_memory(Base):
         from scipy.optimize import curve_fit
 
         ret_fig = []
-        t_low = self.t_arr[IDX_LOW]
-        t_high = self.t_arr[IDX_HIGH]
-
         if all_plots:
             # Plot raw store data for first iteration as a check
+            t_low, t_high = self._store_t_analysis()
             fig1, ax1 = plt.subplots(2, 1, sharex=True, tight_layout=True)
             ax11, ax12 = ax1
             ax11.axvspan(1e9 * t_low, 1e9 * t_high, facecolor="#dfdfdf")
@@ -254,7 +249,8 @@ class Sweep_memory(Base):
             ret_fig.append(fig1)
 
         # Analyze
-        resp_arr = np.mean(self.store_arr[:, 0, IDX_LOW:IDX_HIGH], axis=-1)
+        idx_low, idx_high = self._store_idx_analysis()
+        resp_arr = np.mean(self.store_arr[:, 0, idx_low:idx_high], axis=-1)
         data = rotate_opt(resp_arr)
 
         data_max = np.abs(data).max()

--- a/t1.py
+++ b/t1.py
@@ -11,13 +11,10 @@ import numpy.typing as npt
 from presto import pulsed
 from presto.utils import format_precision, rotate_opt, sin2
 
-from _base import Base, project
-
-IDX_LOW = 0
-IDX_HIGH = -1
+from _base import PlsBase, project
 
 
-class T1(Base):
+class T1(PlsBase):
     def __init__(
         self,
         readout_freq: float,
@@ -203,7 +200,8 @@ class T1(Base):
         assert self.store_arr is not None
 
         if reference_templates is None:
-            resp_arr = np.mean(self.store_arr[:, 0, IDX_LOW:IDX_HIGH], axis=-1)
+            idx_low, idx_high = self._store_idx_analysis()
+            resp_arr = np.mean(self.store_arr[:, 0, idx_low:idx_high], axis=-1)
             data = np.real(rotate_opt(resp_arr))
         else:
             resp_arr = self.store_arr[:, 0, :]
@@ -224,11 +222,9 @@ class T1(Base):
         import matplotlib.pyplot as plt
 
         ret_fig = []
-        t_low = self.t_arr[IDX_LOW]
-        t_high = self.t_arr[IDX_HIGH]
-
         if all_plots:
             # Plot raw store data for first iteration as a check
+            t_low, t_high = self._store_t_analysis()
             fig1, ax1 = plt.subplots(2, 1, sharex=True, tight_layout=True)
             ax11, ax12 = ax1
             ax11.axvspan(1e9 * t_low, 1e9 * t_high, facecolor="#dfdfdf")
@@ -240,7 +236,8 @@ class T1(Base):
             ret_fig.append(fig1)
 
         # Analyze T1
-        resp_arr = np.mean(self.store_arr[:, 0, IDX_LOW:IDX_HIGH], axis=-1)
+        idx_low, idx_high = self._store_idx_analysis()
+        resp_arr = np.mean(self.store_arr[:, 0, idx_low:idx_high], axis=-1)
         resp_arr = rotate_opt(resp_arr)
 
         # Fit data

--- a/t1_memory_coherent.py
+++ b/t1_memory_coherent.py
@@ -10,13 +10,10 @@ import numpy.typing as npt
 from presto import pulsed
 from presto.utils import format_precision, rotate_opt, sin2
 
-from _base import Base
-
-IDX_LOW = 0
-IDX_HIGH = -1
+from _base import PlsBase
 
 
-class T1_memory_coherent(Base):
+class T1_memory_coherent(PlsBase):
     def __init__(
         self,
         readout_freq: float,
@@ -215,11 +212,9 @@ class T1_memory_coherent(Base):
         import matplotlib.pyplot as plt
 
         ret_fig = []
-        t_low = self.t_arr[IDX_LOW]
-        t_high = self.t_arr[IDX_HIGH]
-
         if all_plots:
             # Plot raw store data for first iteration as a check
+            t_low, t_high = self._store_t_analysis()
             fig1, ax1 = plt.subplots(2, 1, sharex=True, tight_layout=True)
             ax11, ax12 = ax1
             ax11.axvspan(1e9 * t_low, 1e9 * t_high, facecolor="#dfdfdf")
@@ -231,7 +226,8 @@ class T1_memory_coherent(Base):
             ret_fig.append(fig1)
 
         # Analyze T1
-        resp_arr = np.mean(self.store_arr[:, 0, IDX_LOW:IDX_HIGH], axis=-1)
+        idx_low, idx_high = self._store_idx_analysis()
+        resp_arr = np.mean(self.store_arr[:, 0, idx_low:idx_high], axis=-1)
         resp_arr = rotate_opt(resp_arr)
 
         # Fit data

--- a/t2_memory_coherent.py
+++ b/t2_memory_coherent.py
@@ -10,13 +10,10 @@ import numpy.typing as npt
 from presto import pulsed
 from presto.utils import format_precision, rotate_opt, sin2
 
-from _base import Base, project
-
-IDX_LOW = 0
-IDX_HIGH = -1
+from _base import PlsBase
 
 
-class T2_memory_coherent(Base):
+class T2_memory_coherent(PlsBase):
     def __init__(
         self,
         readout_freq: float,
@@ -214,25 +211,6 @@ class T2_memory_coherent(Base):
 
         return self
 
-    def analyze_batch(self, reference_templates: Optional[tuple] = None):
-        assert self.t_arr is not None
-        assert self.store_arr is not None
-
-        if reference_templates is None:
-            resp_arr = np.mean(self.store_arr[:, 0, IDX_LOW:IDX_HIGH], axis=-1)
-            data = np.real(rotate_opt(resp_arr))
-        else:
-            resp_arr = self.store_arr[:, 0, :]
-            data = project(resp_arr, reference_templates)
-
-        try:
-            popt, perr = _fit_simple(self.delay_arr, data)
-        except Exception as err:
-            print(f"unable to fit T1: {err}")
-            popt, perr = None, None
-
-        return data, (popt, perr)
-
     def analyze(self, all_plots: bool = False):
         assert self.t_arr is not None
         assert self.store_arr is not None
@@ -240,11 +218,9 @@ class T2_memory_coherent(Base):
         import matplotlib.pyplot as plt
 
         ret_fig = []
-        t_low = self.t_arr[IDX_LOW]
-        t_high = self.t_arr[IDX_HIGH]
-
         if all_plots:
             # Plot raw store data for first iteration as a check
+            t_low, t_high = self._store_t_analysis()
             fig1, ax1 = plt.subplots(2, 1, sharex=True, tight_layout=True)
             ax11, ax12 = ax1
             ax11.axvspan(1e9 * t_low, 1e9 * t_high, facecolor="#dfdfdf")
@@ -256,7 +232,8 @@ class T2_memory_coherent(Base):
             ret_fig.append(fig1)
 
         # Analyze T2
-        resp_arr = np.mean(self.store_arr[:, 0, IDX_LOW:IDX_HIGH], axis=-1)
+        idx_low, idx_high = self._store_idx_analysis()
+        resp_arr = np.mean(self.store_arr[:, 0, idx_low:idx_high], axis=-1)
         data = rotate_opt(resp_arr)
 
         # Fit data to I quadrature

--- a/two_tone_ef.py
+++ b/two_tone_ef.py
@@ -13,13 +13,10 @@ import numpy.typing as npt
 from presto import pulsed
 from presto.utils import rotate_opt, sin2
 
-from _base import Base
-
-IDX_LOW = 0
-IDX_HIGH = -1
+from _base import PlsBase
 
 
-class TwoToneEF(Base):
+class TwoToneEF(PlsBase):
     def __init__(
         self,
         readout_freq: float,
@@ -269,12 +266,9 @@ class TwoToneEF(Base):
         from scipy.optimize import curve_fit
 
         ret_fig = []
-
-        t_low = self.t_arr[IDX_LOW]
-        t_high = self.t_arr[IDX_HIGH]
-
         if all_plots:
             # Plot raw store data for first iteration as a check
+            t_low, t_high = self._store_t_analysis()
             fig1, ax1 = plt.subplots(2, 1, sharex=True, tight_layout=True)
             ax11, ax12 = ax1
             ax11.axvspan(1e9 * t_low, 1e9 * t_high, facecolor="#dfdfdf")
@@ -286,7 +280,8 @@ class TwoToneEF(Base):
             ret_fig.append(fig1)
 
         # Analyze
-        resp_arr = np.mean(self.store_arr[:, 0, IDX_LOW:IDX_HIGH], axis=-1)
+        idx_low, idx_high = self._store_idx_analysis()
+        resp_arr = np.mean(self.store_arr[:, 0, idx_low:idx_high], axis=-1)
         data = rotate_opt(resp_arr)
 
         data_max = np.abs(data).max()

--- a/two_tone_pulsed.py
+++ b/two_tone_pulsed.py
@@ -13,13 +13,10 @@ import numpy.typing as npt
 from presto import pulsed
 from presto.utils import rotate_opt, sin2
 
-from _base import Base
-
-IDX_LOW = 0
-IDX_HIGH = -1
+from _base import PlsBase
 
 
-class TwoTonePulsed(Base):
+class TwoTonePulsed(PlsBase):
     def __init__(
         self,
         readout_freq: float,
@@ -237,12 +234,9 @@ class TwoTonePulsed(Base):
         from scipy.optimize import curve_fit
 
         ret_fig = []
-
-        t_low = self.t_arr[IDX_LOW]
-        t_high = self.t_arr[IDX_HIGH]
-
         if all_plots:
             # Plot raw store data for first iteration as a check
+            t_low, t_high = self._store_t_analysis()
             fig1, ax1 = plt.subplots(2, 1, sharex=True, tight_layout=True)
             ax11, ax12 = ax1
             ax11.axvspan(1e9 * t_low, 1e9 * t_high, facecolor="#dfdfdf")
@@ -254,7 +248,8 @@ class TwoTonePulsed(Base):
             ret_fig.append(fig1)
 
         # Analyze
-        resp_arr = np.mean(self.store_arr[:, 0, IDX_LOW:IDX_HIGH], axis=-1)
+        idx_low, idx_high = self._store_idx_analysis()
+        resp_arr = np.mean(self.store_arr[:, 0, idx_low:idx_high], axis=-1)
         data = rotate_opt(resp_arr)
 
         data_max = np.abs(data).max()

--- a/wigner.py
+++ b/wigner.py
@@ -10,13 +10,10 @@ import numpy.typing as npt
 from presto import pulsed
 from presto.utils import rotate_opt, sin2
 
-from _base import Base
-
-IDX_LOW = 0
-IDX_HIGH = -1
+from _base import PlsBase
 
 
-class Wigner(Base):
+class Wigner(PlsBase):
     def __init__(
         self,
         readout_freq: float,
@@ -244,11 +241,9 @@ class Wigner(Base):
         import matplotlib.pyplot as plt
 
         ret_fig = []
-        t_low = self.t_arr[IDX_LOW]
-        t_high = self.t_arr[IDX_HIGH]
-
         if all_plots:
             # Plot raw store data for first iteration as a check
+            t_low, t_high = self._store_t_analysis()
             fig0, ax0 = plt.subplots(2, 1, sharex=True, tight_layout=True)
             ax01, ax02 = ax0
             ax01.axvspan(1e9 * t_low, 1e9 * t_high, facecolor="#dfdfdf")
@@ -260,7 +255,8 @@ class Wigner(Base):
             ret_fig.append(fig0)
 
         # Analyze
-        resp_arr = np.mean(self.store_arr[:, 0, IDX_LOW:IDX_HIGH], axis=-1)
+        idx_low, idx_high = self._store_idx_analysis()
+        resp_arr = np.mean(self.store_arr[:, 0, idx_low:idx_high], axis=-1)
         resp_arr.shape = (len(self.memory_amp_arr_y), len(self.memory_amp_arr_x))
         resp_arr = rotate_opt(resp_arr) * np.exp(1j * np.pi)
         resp_arr = resp_arr.real


### PR DESCRIPTION
Fixes #3 

`IDX_LOW` and `IDX_HIGH` used to be module constants defined in each measurement script. Now they are class variables in the base class `PlsBase`, which every pulsed measurement inherits from.

By default, all data points in the `store` array will be used for analysis. To use only data points at e.g. indexes `[100:350]`:
```python
experiment = RabiAmp.load("data/rabi_amp_20220413_082434.h5")
# use only store data starting from index 100 (inclusive) and ending at index 350 (exclusive)
experiment.IDX_LOW = 100
experiment.IDX_HIGH = 350
experiment.analyze()
```